### PR TITLE
Change migration generator to reversible style

### DIFF
--- a/lib/sinatra/activerecord/rake.rb
+++ b/lib/sinatra/activerecord/rake.rb
@@ -17,10 +17,7 @@ module Sinatra
       File.open(migration_file, 'w') do |file|
         file.write <<-MIGRATION.strip_heredoc
           class #{migration_class} < ActiveRecord::Migration
-            def up
-            end
-
-            def down
+            def change
             end
           end
         MIGRATION


### PR DESCRIPTION
The [primary] way of migrating in ActiveRecord is using the new reversible
migrations with the `change` method. The generator was using the old
`up/down` style, so this commit changes that. It _should_ be more common
to use the `change` style than to use the `up/down` style, so this
change should generate better migration files.

[primary]:
http://guides.rubyonrails.org/migrations.html#using-the-change-method
