### PR TITLE
Default config/database.yml fetched from the pwd

### DIFF
--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -47,7 +47,7 @@ module Sinatra
     def self.registered(app)
       app.set :activerecord_logger, Logger.new(STDOUT)
       app.set :database_spec, ENV['DATABASE_URL']
-      app.set :database_file, "config/database.yml"
+      app.set :database_file, "#{Dir.pwd}/config/database.yml"
       app.database if app.database_spec
       app.helpers ActiveRecordHelper
 


### PR DESCRIPTION
Hi!

I'm using this gem for a [personal project](https://github.com/squareteam/yodatra) but I needed to load this gem not in the usual context of a Sinatra app but in a middleware for Sinatra.

For a default configuration of  the DB file, I think it would be more generic to give a abs path (rather than a rel path) with the process working directory.

What do you think abt it?

Thanks!
