### PR TITLE
Add db:test:prepare

### DIFF
--- a/lib/sinatra/activerecord/tasks.rake
+++ b/lib/sinatra/activerecord/tasks.rake
@@ -49,4 +49,24 @@ namespace :db do
       Sinatra::ActiveRecordTasks.load_schema()
     end
   end
+
+  namespace :test do
+    task :purge do
+      Sinatra::ActiveRecordTasks.with_config_environment 'test' do
+        Sinatra::ActiveRecordTasks.purge()
+      end
+    end
+
+    task :load => :purge do
+      ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations['test'])
+      Sinatra::ActiveRecordTasks.with_config_environment 'test' do
+        Sinatra::ActiveRecordTasks.load_schema()
+      end
+    end
+
+    desc 'Prepare test database from development schema'
+    task :prepare do
+      Rake::Task["db:test:load"].invoke
+    end
+  end
 end

--- a/spec/fixtures/database.yml
+++ b/spec/fixtures/database.yml
@@ -1,3 +1,7 @@
 development:
   adapter: "sqlite3"
   database: "tmp/foo.sqlite3"
+
+test:
+  adapter: "sqlite3"
+  database: "tmp/foo_test.sqlite3"


### PR DESCRIPTION
This emulates the Railtie implementation, so that you can do `rake db:test:prepare`, and it will use the `test` environment to purge and load the schema into the test database, exactly the same way as with Rails apps. This makes it easier to treat Sinatra apps just like Rails app when it comes to both local and CI testing.

I found writing the test a bit awkward as the tests really exercise the Rake task _module_, not the Rake tasks themselves, contrary to the descriptions, and there are some assumptions — specifically, that `ActiveRecord::Base.configurations` was not populated in the tests — that I had to fight against.
