### PR TITLE
Added ability for schema dump to output sql schema

### DIFF
--- a/lib/sinatra/activerecord/rake.rb
+++ b/lib/sinatra/activerecord/rake.rb
@@ -64,7 +64,7 @@ module Sinatra
       end
     end
 
-    def dump_schema(file_name = 'db/schema.rb')
+    def dump_schema(file_name = schema_format_file)
       silence_activerecord do
         ActiveRecord::Migration.suppress_messages do
           # Create file
@@ -86,7 +86,7 @@ module Sinatra
       end
     end
 
-    def load_schema(file_name = 'db/schema.rb')
+    def load_schema(file_name = schema_format_file)
       load(file_name)
     end
 
@@ -123,6 +123,12 @@ module Sinatra
       ActiveRecord::Base.logger = nil
       yield if block_given?
       ActiveRecord::Base.logger = old_logger
+    end
+
+    def schema_format_file
+      file_name = 'db/structure.sql' if ActiveRecord::Base.schema_format == :sql
+      file_name = 'db/schema.rb' if ActiveRecord::Base.schema_format == :ruby
+      file_name
     end
   end
 end

--- a/lib/sinatra/activerecord/tasks.rake
+++ b/lib/sinatra/activerecord/tasks.rake
@@ -29,13 +29,13 @@ namespace :db do
   desc "migrate the database (use version with VERSION=n)"
   task :migrate do
     Sinatra::ActiveRecordTasks.migrate(ENV["VERSION"])
-    Rake::Task["db:schema:dump"].invoke if ActiveRecord::Base.schema_format == :ruby
+    Rake::Task["db:schema:dump"].invoke if [:sql, :ruby].include? ActiveRecord::Base.schema_format
   end
 
   desc "roll back the migration (use steps with STEP=n)"
   task :rollback do
     Sinatra::ActiveRecordTasks.rollback(ENV["STEP"])
-    Rake::Task["db:schema:dump"].invoke if ActiveRecord::Base.schema_format == :ruby
+    Rake::Task["db:schema:dump"].invoke if [:sql, :ruby].include? ActiveRecord::Base.schema_format
   end
 
   namespace :schema do


### PR DESCRIPTION
If you specify:

```
ActiveRecord::Base.schema_format = :sql
```

These change will honor that setting now and output to structure.sql as it would in a Rails environment.

Tests still pass.
