### PR TITLE
allow for dumping sql

### DIFF
--- a/lib/sinatra/activerecord/rake.rb
+++ b/lib/sinatra/activerecord/rake.rb
@@ -78,6 +78,10 @@ module Sinatra
       end
     end
 
+    def dump_structure(file_name = 'db/structure.sql')
+      ActiveRecord::Tasks::DatabaseTasks.structure_dump(config, file_name)
+    end
+
     def purge
       if config
         ActiveRecord::Tasks::DatabaseTasks.purge(config)
@@ -88,6 +92,10 @@ module Sinatra
 
     def load_schema(file_name = 'db/schema.rb')
       load(file_name)
+    end
+
+    def load_structure(file_name = 'db/structure.sql')
+      ActiveRecord::Tasks::DatabaseTasks.structure_load(config, file_name)
     end
 
     def with_config_environment(environment, &block)
@@ -111,7 +119,9 @@ module Sinatra
     end
 
     def config
-      ActiveRecord::Base.configurations[config_environment]
+      ActiveRecord::Base.configurations[config_environment] ||
+        #active record expects the keys to be strings, but connection_config returns them as symbols
+        Hash[ActiveRecord::Base.connection_config.map{|key, value| [key.to_s, value]}]
     end
 
     def migrations_dir

--- a/lib/sinatra/activerecord/tasks.rake
+++ b/lib/sinatra/activerecord/tasks.rake
@@ -29,13 +29,21 @@ namespace :db do
   desc "migrate the database (use version with VERSION=n)"
   task :migrate do
     Sinatra::ActiveRecordTasks.migrate(ENV["VERSION"])
-    Rake::Task["db:schema:dump"].invoke if ActiveRecord::Base.schema_format == :ruby
+
+    case ActiveRecord::Base.schema_format
+      when :ruby then Rake::Task["db:schema:dump"].invoke
+      when :sql  then Rake::Task["db:structure:dump"].invoke
+    end
   end
 
   desc "roll back the migration (use steps with STEP=n)"
   task :rollback do
     Sinatra::ActiveRecordTasks.rollback(ENV["STEP"])
-    Rake::Task["db:schema:dump"].invoke if ActiveRecord::Base.schema_format == :ruby
+
+    case ActiveRecord::Base.schema_format
+      when :ruby then Rake::Task["db:schema:dump"].invoke
+      when :sql  then Rake::Task["db:structure:dump"].invoke
+    end
   end
 
   namespace :schema do
@@ -47,6 +55,18 @@ namespace :db do
     desc "load schema into database"
     task :load do
       Sinatra::ActiveRecordTasks.load_schema()
+    end
+  end
+
+  namespace :structure do
+    desc "dump schema into a file as SQL"
+    task :dump do
+      Sinatra::ActiveRecordTasks.dump_structure()
+    end
+
+    desc "load schema into database"
+    task :load do
+      Sinatra::ActiveRecordTasks.load_structure()
     end
   end
 


### PR DESCRIPTION
#24 doesn't work, since it just dumps the ruby schema into a .sql file; it never gets the actual SQL code at all. This PR fixes that and also addresses the other issues in #24: migrate does the right thing, but `schema:dump` always dumps Ruby and `structure:dump` always dumps SQL.
