### PR TITLE
Add db:reset and db:migrate:reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ rake db:create                     # create the database from config/database.ym
 rake db:create_migration           # create an ActiveRecord migration
 rake db:drop                       # drops the data from config/database.yml from the current Sinatra env
 rake db:migrate                    # migrate the database (use version with VERSION=n)
+rake db:migrate:reset              # drops and creates the database and then runs the migrations
+rake db:reset                      # drops and creates the database
 rake db:rollback                   # roll back the migration (use steps with STEP=n)
 rake db:schema:dump                # dump schema into file
 rake db:schema:load                # load schema into database

--- a/lib/sinatra/activerecord/tasks.rake
+++ b/lib/sinatra/activerecord/tasks.rake
@@ -36,6 +36,12 @@ namespace :db do
     end
   end
 
+  namespace :migrate do
+    task :reset => ['db:drop', 'db:create', 'db:migrate']
+  end
+
+  task :reset => ['db:drop', 'db:setup']
+
   desc "roll back the migration (use steps with STEP=n)"
   task :rollback do
     Sinatra::ActiveRecordTasks.rollback(ENV["STEP"])


### PR DESCRIPTION
This is the exactly the same as Rails' `rake db:reset` and `rake db:migrate:reset`.

`rake db:reset` runs `rake db:drop` and `rake db:setup`.
`rake db:migrate:reset` runs `rake db:drop`, `rake db:create`, and `rake db:migrate`.

I'm not entirely sure how to go about testing the Rake tasks so any help there would be greatly appreciated.
