### PR TITLE
Use symblized environment string

### DIFF
--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -34,7 +34,7 @@ module Sinatra
     end
 
     def database=(spec)
-      if spec.is_a?(Hash) and spec.symbolize_keys[environment]
+      if spec.is_a?(Hash) and spec.symbolize_keys[environment.to_sym]
         ActiveRecord::Base.configurations = spec.stringify_keys
         ActiveRecord::Base.establish_connection(environment)
       else


### PR DESCRIPTION
Hi, I found an issue when I set the environment as a string. Could you consider to merge this fix?
