### PR TITLE
Don't log to STDOUT on production.

### DIFF
--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -18,7 +18,7 @@ module Sinatra
     def self.registered(app)
       app.set :database, ENV['DATABASE_URL'] if ENV['DATABASE_URL']
       app.set :database_file, "#{Dir.pwd}/config/database.yml" if File.exist?("#{Dir.pwd}/config/database.yml")
-      ActiveRecord::Base.logger = Logger.new(STDOUT) unless defined?(Rake)
+      ActiveRecord::Base.logger = Logger.new(STDOUT) unless defined?(Rake) || app.settings.production?
 
       app.helpers ActiveRecordHelper
 

--- a/spec/sinatra/activerecord_spec.rb
+++ b/spec/sinatra/activerecord_spec.rb
@@ -18,7 +18,12 @@ RSpec.describe "the sinatra extension" do
   end
 
   before do
+    hide_const("Rake")
     ActiveRecord::Base.remove_connection
+  end
+
+  after do
+    ActiveRecord::Base.logger = nil
   end
 
   it "exposes ActiveRecord::Base" do
@@ -87,6 +92,22 @@ RSpec.describe "the sinatra extension" do
 
     expect{ActiveRecord::Base.connection}.not_to raise_error
   end
+
+
+  it "should log to STDOUT by default" do
+    expect(app.database.logger).to be_kind_of(Logger)
+  end
+
+  it "should not log to STDOUT if Rake is not defined" do
+    stub_const("Rake", Module.new)
+    expect(app.database.logger).to be_nil
+  end
+
+  it "should not log to STDOUT in production" do
+    app.environment = :production
+    expect(app.database.logger).to be_nil
+  end
+
 
   it "raises an error on invalid database.yml" do
     FileUtils.touch("tmp/database.yml")


### PR DESCRIPTION
- Added a condition to not set the logger on production environment.
- Created a spec with three scenarios to cover all cases:
  - With no extra configuration.
  - Where rake is defined.
  - When on production.
- Setup the test environment to hide Rake before each scenario.
- Setup the test environment to unset the Logger after each scenario.

This closes #43.
