### PR TITLE
Allow rake db:create_migration to be called without named env

### DIFF
--- a/lib/sinatra/activerecord/tasks.rake
+++ b/lib/sinatra/activerecord/tasks.rake
@@ -5,12 +5,12 @@ require "fileutils"
 namespace :db do
   desc "Create a migration (parameters: NAME, VERSION)"
   task :create_migration do
-    unless ENV["NAME"]
+    unless ENV["NAME"] || ARGV[1]
       puts "No NAME specified. Example usage: `rake db:create_migration NAME=create_users`"
       exit
     end
 
-    name    = ENV["NAME"]
+    name    = ENV["NAME"] || ARGV[1]
     version = ENV["VERSION"] || Time.now.utc.strftime("%Y%m%d%H%M%S")
 
     ActiveRecord::Migrator.migrations_paths.each do |directory|

--- a/lib/sinatra/activerecord/tasks.rake
+++ b/lib/sinatra/activerecord/tasks.rake
@@ -11,7 +11,7 @@ namespace :db do
     end
 
     name    = ENV["NAME"] || ARGV[1]
-    version = ENV["VERSION"] || Time.now.utc.strftime("%Y%m%d%H%M%S")
+    version = ENV["VERSION"] || ARGV[2] || Time.now.utc.strftime("%Y%m%d%H%M%S")
 
     ActiveRecord::Migrator.migrations_paths.each do |directory|
       next unless File.exist?(directory)

--- a/spec/sinatra/activerecord/rake_spec.rb
+++ b/spec/sinatra/activerecord/rake_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe "the rake tasks" do
     require 'sinatra/activerecord/rake'
 
     module TaskWithReenable
-      def invoke
-        super
+      def invoke(*args)
+        super(*args)
         reenable
       end
     end
@@ -39,15 +39,56 @@ RSpec.describe "the rake tasks" do
   end
 
   it "has all the rake tasks working" do
-    ENV["NAME"] = "create_users"
+    begin
+      ENV["NAME"] = "create_users"
 
-    Rake::Task["db:create"].invoke
-    Rake::Task["db:create_migration"].invoke
-    Rake::Task["db:migrate"].invoke
-    Rake::Task["db:migrate:redo"].invoke
-    Rake::Task["db:reset"].invoke
-    Rake::Task["db:seed"].invoke
+      Rake::Task["db:create"].invoke
+      Rake::Task["db:create_migration"].invoke
+      Rake::Task["db:migrate"].invoke
+      Rake::Task["db:migrate:redo"].invoke
+      Rake::Task["db:reset"].invoke
+      Rake::Task["db:seed"].invoke
 
-    ENV.delete("NAME")
+      ENV.delete("NAME")
+    rescue SystemExit
+      fail 'should not exit'
+    end
+
+    # ensure the migration file is created
+    migration_file = Dir["#{FileUtils.pwd}/db/migrate/*_create_users.rb"]
+    expect(migration_file).not_to be_empty
+
+    schema_file = Dir["#{FileUtils.pwd}/db/schema.rb"]
+    expect(schema_file).not_to be_empty
+
+    seeds_file = Dir["#{FileUtils.pwd}/db/seeds.rb"]
+    expect(seeds_file).not_to be_empty
+  end
+
+  it 'works with providing argument instead of named env param' do
+    begin
+      ARGV[1] = 'create_users'
+
+      Rake::Task["db:create"].invoke
+      Rake::Task["db:create_migration"].invoke
+      Rake::Task["db:migrate"].invoke
+      Rake::Task["db:migrate:redo"].invoke
+      Rake::Task["db:reset"].invoke
+      Rake::Task["db:seed"].invoke
+
+      ARGV = []
+    rescue SystemExit
+      fail 'should not exit'
+    end
+
+    # ensure the migration file is created
+    migration_file = Dir["#{FileUtils.pwd}/db/migrate/*_create_users.rb"]
+    expect(migration_file).not_to be_empty
+
+    schema_file = Dir["#{FileUtils.pwd}/db/schema.rb"]
+    expect(schema_file).not_to be_empty
+
+    seeds_file = Dir["#{FileUtils.pwd}/db/seeds.rb"]
+    expect(seeds_file).not_to be_empty
   end
 end


### PR DESCRIPTION
Allow rake db:create_migration to be called without named env

eg: `rake db:create_migration create_users` can be used along with `rake db:create_migration NAME=create_users`

If you want to specify version manually, use the second parameter , eg: `rake db:create_migration create_users v2`

Thanks @madacol for the suggestion in #82 
