### PR TITLE
Set configurations with new hash directly

### DIFF
--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -43,13 +43,21 @@ module Sinatra
       if spec.is_a?(Hash) and spec.symbolize_keys[environment.to_sym]
         ActiveRecord::Base.configurations = spec.stringify_keys
         ActiveRecord::Base.establish_connection(environment.to_sym)
-      elsif spec.is_a?(Hash)
-        ActiveRecord::Base.configurations[environment.to_s] = spec.stringify_keys
+      elsif spec.is_a?(Hash)     
+        ActiveRecord::Base.configurations = {
+          environment.to_s => spec.stringify_keys
+        }
+
         ActiveRecord::Base.establish_connection(spec.stringify_keys)
       else
+        if Gem.loaded_specs["activerecord"].version >= Gem::Version.create('6.0')
+          ActiveRecord::Base.configurations ||= ActiveRecord::DatabaseConfigurations.new({}).resolve(spec)
+        else
+          ActiveRecord::Base.configurations ||= {}
+          ActiveRecord::Base.configurations[environment.to_s] = ActiveRecord::ConnectionAdapters::ConnectionSpecification::ConnectionUrlResolver.new(spec).to_hash
+        end
+
         ActiveRecord::Base.establish_connection(spec)
-        ActiveRecord::Base.configurations ||= {}
-        ActiveRecord::Base.configurations[environment.to_s] = ActiveRecord::ConnectionAdapters::ConnectionSpecification::ConnectionUrlResolver.new(spec).to_hash
       end
     end
 

--- a/spec/sinatra/activerecord/rake_spec.rb
+++ b/spec/sinatra/activerecord/rake_spec.rb
@@ -75,8 +75,6 @@ RSpec.describe "the rake tasks" do
       Rake::Task["db:migrate:redo"].invoke
       Rake::Task["db:reset"].invoke
       Rake::Task["db:seed"].invoke
-
-      ARGV = []
     rescue SystemExit
       fail 'should not exit'
     end


### PR DESCRIPTION
Set configurations with new hash directly, as ActiveRecord 6 onwards deprecate modifying hash value directly on DatabaseConfigurations.

Fixes #89 