### PR TITLE
prefer APP_ENV to RACK_ENV

### DIFF
--- a/lib/sinatra/activerecord/rake/activerecord_6.rb
+++ b/lib/sinatra/activerecord/rake/activerecord_6.rb
@@ -6,7 +6,7 @@ end
 
 ActiveRecord::Tasks::DatabaseTasks.tap do |config|
   config.root                   = Rake.application.original_dir
-  config.env                    = ENV["RACK_ENV"] || "development"
+  config.env                    = ENV["APP_ENV"] || ENV["RACK_ENV"] || "development"
   config.db_dir                 = "db"
   config.migrations_paths       = ["db/migrate"]
   config.fixtures_path          = "test/fixtures"


### PR DESCRIPTION
This PR also applies #78 to activerecord_6.

#78 was created in 2017, before Rails6 was released.