### PR TITLE
DO NOT MERGE

### DIFF
--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -1,6 +1,7 @@
 require 'sinatra/base'
 require 'active_record'
 require 'active_support/core_ext/hash/keys'
+require 'active_record/database_configurations/connection_url_resolver'
 
 require 'logger'
 require 'pathname'

--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -22,7 +22,7 @@ module Sinatra
         file_path = File.join(root, path) if Pathname(path).relative? and root
         file_spec = YAML.load(ERB.new(File.read(path)).result) || {}
 
-        url_spec = ActiveRecord::ConnectionAdapters::ConnectionSpecification::ConnectionUrlResolver.new(url).to_hash
+        url_spec = ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver.new(url).to_hash
 
         # url_spec will override the same key, if exist
         final_spec = file_spec.keys.map{ |env| [env, file_spec[env].merge(url_spec)] }.to_h


### PR DESCRIPTION
I have made this a pull request to remind myself.

For `ActiveRecord 6.1.0`, it appears `ActiveRecord::ConnectionAdapters::ConnectionSpecification::ConnectionUrlResolver` has been deprecated and removed from the codebase. This was affirmed by issue #107 (I think??).

I was receiving the following on deployment to Heroku:

```
NameError: uninitialized constant ActiveRecord::ConnectionAdapters::ConnectionSpecification
/app/vendor/bundle/ruby/2.7.0/gems/sinatra-activerecord-2.0.21/lib/sinatra/activerecord.rb:25:in `registered'
/app/vendor/bundle/ruby/2.7.0/gems/sinatra-2.1.0/lib/sinatra/base.rb:1455:in `block in register'
/app/vendor/bundle/ruby/2.7.0/gems/sinatra-2.1.0/lib/sinatra/base.rb:1453:in `each'
/app/vendor/bundle/ruby/2.7.0/gems/sinatra-2.1.0/lib/sinatra/base.rb:1453:in `register'
/app/vendor/bundle/ruby/2.7.0/gems/sinatra-2.1.0/lib/sinatra/base.rb:1947:in `register'
/app/vendor/bundle/ruby/2.7.0/gems/sinatra-2.1.0/lib/sinatra/base.rb:2008:in `register'
/app/vendor/bundle/ruby/2.7.0/gems/sinatra-activerecord-2.0.21/lib/sinatra/activerecord.rb:81:in `<module:Sinatra>'
/app/vendor/bundle/ruby/2.7.0/gems/sinatra-activerecord-2.0.21/lib/sinatra/activerecord.rb:10:in `<top (required)>'
/app/vendor/bundle/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:74:in `require'
/app/vendor/bundle/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:74:in `block (2 levels) in require'
/app/vendor/bundle/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:69:in `each'
/app/vendor/bundle/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:69:in `block in require'
/app/vendor/bundle/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:58:in `each'
/app/vendor/bundle/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/runtime.rb:58:in `require'
/app/vendor/bundle/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler.rb:174:in `require'
/app/config/environment.rb:26:in `<top (required)>'
/app/Rakefile:20:in `require_relative'
/app/Rakefile:20:in `<top (required)>'
```

Upon searching around, it was discovered that the URL resolver has not been removed, but moved to [this location](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb).

Therefore, the solution to the above error is to call this new class.

My only issue is I don't know when the change occurred, and how to determine when to use the new class. Perhaps if we put some conditional logic as to whether ActiveRecord is at version 6.1.0 or something.

Either way, my code solved the problem for me. I will change it, but we need to ensure it will only load where appropriate.

Rich