### PR TITLE
Don't inject DATABASE_URL config if multiple db config

### DIFF
--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -30,9 +30,17 @@ module Sinatra
         else
           url_spec = ActiveRecord::ConnectionAdapters::ConnectionSpecification::ConnectionUrlResolver.new(url).to_hash
         end
-        
-        # url_spec will override the same key, if exist
-        final_spec = file_spec.keys.map{ |env| [env, file_spec[env].merge(url_spec)] }.to_h
+
+        # url_spec will override the same key, if exist, and if the
+        # configuration concerns only one database
+        final_spec = file_spec.keys.map do |env|
+          config = file_spec[env]
+          if config.is_a?(Hash) && config.all? { |_k, v| v.is_a?(Hash) }
+            [env, config]
+          else
+            [env, config.merge(url_spec)]
+          end
+        end.to_h
 
         app.set :database, final_spec
       elsif ENV['DATABASE_URL']

--- a/spec/fixtures/database.yml
+++ b/spec/fixtures/database.yml
@@ -12,3 +12,13 @@ another_test:
   adapter: "sqlite3"
   database: "tmp/bar_test.sqlite3"
   pool: 3
+
+multiple_db_test:
+  primary:
+    adapter: "sqlite3"
+    database: "tmp/foo.sqlite3"
+    pool: 3
+  secondary:
+    adapter: "sqlite3"
+    database: "tmp/bar_test.sqlite3"
+    pool: 3

--- a/spec/sinatra/activerecord_spec.rb
+++ b/spec/sinatra/activerecord_spec.rb
@@ -108,6 +108,22 @@ RSpec.describe "the sinatra extension" do
     FileUtils.rm_rf("config")
   end
 
+  it "allows specifying multiple environment databases, without URL precedence" do
+    ENV["DATABASE_URL"] = database_url
+    FileUtils.mkdir_p("config")
+    FileUtils.copy_file("#{Dir.pwd}/spec/fixtures/database.yml", "#{Dir.pwd}/config/database.yml")
+
+    app
+    ActiveRecord::Base.establish_connection(:multiple_db_test)
+
+    # it does not use the database name in the URL, but the one defined in database.yml
+    expect(app.database.connection.raw_connection.filename).to_not include(url_sqlite_db_name)
+
+    expect{ActiveRecord::Base.connection}.not_to raise_error
+
+    FileUtils.rm_rf("config")
+  end
+
   it "expands database file path from the app root if present" do
     app.root = "spec/fixtures"
     app.database_file = "database.yml"


### PR DESCRIPTION
ActiveRecord 6 has introduced the possibility to use natively several databases.
In order to define that a configuration of a database environment concerns several databases, ActiveRecord makes a check on the type of the properties defining this configuration.
If all properties are Hash, ActiveRecord considers that it is a configuration of several databases.

For example, this configuration will be treated as configuring several bases for the production environment:

```yml
production:
  primary:
    database: my_primary_database
    user: root
    adapter: mysql
  primary_replica:
    database: my_primary_database
    user: root_readonly
    adapter: mysql
    replica: true
  animals:
    database: my_animals_database
    user: animals_root
    adapter: mysql
    migrations_paths: db/animals_migrate
  animals_replica:
    database: my_animals_database
    user: animals_readonly
    adapter: mysql
    replica: true
```

While this configuration configures only one base for an environment:

```yml
production:
  database: my_primary_database
  user: root
  adapter: mysql
```

The configuration type distinction mechanism was initially introduced in this PR https://github.com/rails/rails/pull/36756/files#diff-f331c79762cf21af77a95e633bad6dbf370260fb7bb98bcb7b06f1dbf8475275R108

We find this mechanism in the master https://github.com/rails/rails/blob/main/activerecord/lib/active_record/database_configurations.rb#L169

Sinatra-ActiveRecord proposes a mechanism to merge the configuration of a database with the parsed data of the environment variable `DATABASE_URL`.
This mechanism is not adapted anymore when the configuration defines several databases because it is not possible to determine on which database configuration the data from the environment variable should be merged.

This PR, allows to set the data merge behavior related to the environment variable.
If the configuration concerns several databases, the merge is not supported. The developer will have to define all the necessary information in the configuration file `database.yml`.
If the configuration concerns only one database, the historical behavior is taken over.