### PR TITLE
For config with multiple database environment (Rails 6+ only), discard URL spec

### DIFF
--- a/spec/fixtures/database.yml
+++ b/spec/fixtures/database.yml
@@ -12,3 +12,13 @@ another_test:
   adapter: "sqlite3"
   database: "tmp/bar_test.sqlite3"
   pool: 3
+
+multiple_db_test:
+  primary:
+    adapter: "sqlite3"
+    database: "tmp/foo.sqlite3"
+    pool: 3
+  secondary:
+    adapter: "sqlite3"
+    database: "tmp/bar_test.sqlite3"
+    pool: 3

--- a/spec/sinatra/activerecord_spec.rb
+++ b/spec/sinatra/activerecord_spec.rb
@@ -108,6 +108,22 @@ RSpec.describe "the sinatra extension" do
     FileUtils.rm_rf("config")
   end
 
+  it "allows specifying multiple environment databases, without URL precedence", if: ActiveRecord::VERSION::MAJOR >= 6 do
+    ENV["DATABASE_URL"] = database_url
+    FileUtils.mkdir_p("config")
+    FileUtils.copy_file("#{Dir.pwd}/spec/fixtures/database.yml", "#{Dir.pwd}/config/database.yml")
+
+    app
+    ActiveRecord::Base.establish_connection(:multiple_db_test)
+
+    # it does not use the database name in the URL, but the one defined in database.yml
+    expect(app.database.connection.raw_connection.filename).to_not include(url_sqlite_db_name)
+
+    expect{ActiveRecord::Base.connection}.not_to raise_error
+
+    FileUtils.rm_rf("config")
+  end
+
   it "expands database file path from the app root if present" do
     app.root = "spec/fixtures"
     app.database_file = "database.yml"


### PR DESCRIPTION
For config with multiple database environment (Rails 6+ only), discard URL spec

Thanks @JoaKimKlaxit for the original PR https://github.com/sinatra-activerecord/sinatra-activerecord/pull/112

I have made some changes on the spec to make it only run on Active Record 6.0+ , as multiple database is only introduced in Rails 6