### PR TITLE
Fix compatibility with Psych >= 4

### DIFF
--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -22,7 +22,9 @@ module Sinatra
         path = "#{Dir.pwd}/config/database.yml"
         url = ENV['DATABASE_URL']
         file_path = File.join(root, path) if Pathname(path).relative? and root
-        file_spec = YAML.load(ERB.new(File.read(path)).result) || {}
+        source = ERB.new(File.read(path)).result
+        file_spec = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(source) : YAML.load(source)
+        file_spec ||= {}
 
         # ActiveRecord 6.1+ has moved the connection url resolver to another module
         if Gem.loaded_specs["activerecord"].version >= Gem::Version.create('6.1')
@@ -64,7 +66,9 @@ module Sinatra
 
     def database_file=(path)
       path = File.join(root, path) if Pathname(path).relative? and root
-      spec = YAML.load(ERB.new(File.read(path)).result) || {}
+      source = ERB.new(File.read(path)).result
+      spec = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(source) : YAML.load(source)
+      spec ||= {}
       set :database, spec
     end
 

--- a/spec/fixtures/database.yml
+++ b/spec/fixtures/database.yml
@@ -22,3 +22,10 @@ multiple_db_test:
     adapter: "sqlite3"
     database: "tmp/bar_test.sqlite3"
     pool: 3
+
+alias: &alias
+  adapter: "sqlite3"
+  database: "tmp/bar_test.sqlite3"
+
+alias_test:
+  <<: *alias


### PR DESCRIPTION
Starting In Psych 4.0.0 YAML.load behaves like YAML.safe_load.
To preserve compatibility, uses YAML.unsafe_load if available.
This should be fine because database.yml is in-repo, and therefore trusted.

https://github.com/ruby/psych/pull/487

I have copied the implementation from rails/rails.