### PR TITLE
Clean ENV after each test

### DIFF
--- a/spec/sinatra/activerecord_spec.rb
+++ b/spec/sinatra/activerecord_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe "the sinatra extension" do
 
     expect{ActiveRecord::Base.connection}.not_to raise_error
 
+    ENV.delete("DATABASE_URL")
     FileUtils.rm_rf("config")
   end
 
@@ -121,6 +122,7 @@ RSpec.describe "the sinatra extension" do
 
     expect{ActiveRecord::Base.connection}.not_to raise_error
 
+    ENV.delete("DATABASE_URL")
     FileUtils.rm_rf("config")
   end
 


### PR DESCRIPTION
These tests set `ENV["DATABASE_URL"]`, but they have not been cleared after the test.