### PR TITLE
CI against Ruby 3.0 and head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.5.x'
-          - '2.6.x'
-          - '2.7.x'
+          - '2.5'
+          - '2.6'
+          - '2.7'
         activerecord:
           - '4.1'
           - '5.0'
@@ -23,7 +23,7 @@ jobs:
           - '6.1'
         exclude:
         # active record 4.1 is not compatible with ruby 2.7 due to BigDecimal changes
-        - ruby: '2.7.x'
+        - ruby: '2.7'
           activerecord: '4.1' 
 
     steps:
@@ -35,7 +35,7 @@ jobs:
         sudo apt-get install libsqlite3-dev
 
     - name: Setup Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
           - '2.5'
           - '2.6'
           - '2.7'
+          - '3.0'
+          - 'head'
         activerecord:
           - '4.1'
           - '5.0'
@@ -25,6 +27,15 @@ jobs:
         # active record 4.1 is not compatible with ruby 2.7 due to BigDecimal changes
         - ruby: '2.7'
           activerecord: '4.1' 
+        # ActiveRecord 5.x doesn't works on Ruby 3.0+
+        - ruby: '3.0'
+          activerecord: '4.1'
+        - ruby: '3.0'
+          activerecord: '5.0'
+        - ruby: 'head'
+          activerecord: '4.1'
+        - ruby: 'head'
+          activerecord: '5.0'
 
     steps:
     - name: Checkout current branch


### PR DESCRIPTION
* Migrate to ruby/setup-ruby
  - [actions/setup-ruby](https://github.com/actions/setup-ruby) is deprecated.
* CI against Ruby `3.0` and `head`
  - exclude ActiveRecord <= 5.2 for Ruby 3.0+
    * sqlite3 gem < v1.4.2 cannot build on Ruby 3.0+
    * AR <= 5.2 specifies sqlite3 gem version
    * https://github.com/rails/rails/blob/v5.2.6/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L12
  - `head` is test for #115