### PR TITLE
feat: resolve deprecation warnings for ActiveRecord 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,18 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
         activerecord:
           - '4.1'
           - '5.0'
           - '6.0'
           - '6.1'
           - '7.0'
+          - '7.1'
         exclude:
         # active record 4.1 is not compatible with ruby 2.7 due to BigDecimal changes
         - ruby: '2.7'
-          activerecord: '4.1' 
+          activerecord: '4.1'
         # ActiveRecord 5.x doesn't work on Ruby 3.0+
         - ruby: '3.0'
           activerecord: '4.1'
@@ -36,9 +38,15 @@ jobs:
           activerecord: '4.1'
         - ruby: '3.1'
           activerecord: '5.0'
+        - ruby: '3.2'
+          activerecord: '4.1'
+        - ruby: '3.2'
+          activerecord: '5.0'
         # ActiveRecord 7.x doesn't work on Ruby 2.6 and below
         - ruby: '2.6'
           activerecord: '7.0'
+        - ruby: '2.6'
+          activerecord: '7.1'
         # Ruby 3.1 has problem with Rails 7 currently (https://gist.github.com/yahonda/2776d8d7b6ea7045359f38c10449937b#add-classdescendants)
         - ruby: '3.1'
           activerecord: '7.0'
@@ -55,19 +63,18 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    
+
     - name : Install dependency
       run: |
         gem install bundler
         bundle install
         gem update --system 3.3.3
-        
+
     - name: Run appraisal to install different active records version
       run: |
         bundle exec appraisal install
-        
+
     - name: Run rspec test across active record
       run: |
         bundle exec appraisal activerecord-${{ matrix.activerecord }} rspec
 
-    

--- a/Appraisals
+++ b/Appraisals
@@ -1,4 +1,8 @@
 if RUBY_VERSION >= '2.7.0'
+  appraise 'activerecord-7.1' do
+    gem 'activerecord', '~> 7.1.0'
+  end
+
   appraise 'activerecord-7.0' do
     gem 'activerecord', '~> 7.0.0'
   end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 
 Ensure the test passes before submitting a Pull Request,
 
-Currently this gem supports ActiveRecord 4.1, 5.0, 6.0 and 7.0, ensure the test works across these ActiveRecord version.
+Currently this gem supports ActiveRecord 4.1, 5.0, 6.0, 7.0 and 7.1 ensure the test works across these ActiveRecord version.
 
 1. Run `bundle exec appraisal` to generate gemfiles required to support different Active Record version
 2. Run `bundle exec appraisal rspec` to run test across different Active Record version

--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -31,7 +31,7 @@ module Sinatra
         else
           url_spec = ActiveRecord::ConnectionAdapters::ConnectionSpecification::ConnectionUrlResolver.new(url).to_hash
         end
-        
+
         # if the configuration concerns only one database, and url_spec exist, url_spec will override the same key
         # if the configuration has multiple databases (Rails 6.0+ feature), url_spec is discarded
         # Following Active Record config convention
@@ -60,7 +60,7 @@ module Sinatra
 
       # re-connect if database connection dropped (Rails 3 only)
       app.before { ActiveRecord::Base.verify_active_connections! if ActiveRecord::Base.respond_to?(:verify_active_connections!) }
-      app.after { ActiveRecord::Base.clear_active_connections! }
+      app.after { ActiveRecord::Base.connection_handler.clear_active_connections! }
     end
 
     def database_file=(path)
@@ -75,7 +75,7 @@ module Sinatra
       if spec.is_a?(Hash) and spec.symbolize_keys[environment.to_sym]
         ActiveRecord::Base.configurations = spec.stringify_keys
         ActiveRecord::Base.establish_connection(environment.to_sym)
-      elsif spec.is_a?(Hash)     
+      elsif spec.is_a?(Hash)
         ActiveRecord::Base.configurations = {
           environment.to_s => spec.stringify_keys
         }


### PR DESCRIPTION
ActiveRecord 7.1 logs a lot of deprecation warnings like:
```
DEPRECATION WARNING: Calling `ActiveRecord::Base.clear_active_connections! is deprecated. Please call the method directly on the connection handler; for example: `ActiveRecord::Base.connection_handler.clear_active_connections!`. (called from clear_active_connections! at /usr/local/bundle/gems/activerecord-7.1.0/lib/active_record/connection_handling.rb:320)
```
 
This PR implements the suggested solution from [link](https://github.com/rails/rails/blob/v7.1.0/activerecord/lib/active_record/connection_handling.rb#L340)