### PR TITLE
Fix deprecation warning seen with ActiveRecord v 7.1

### DIFF
--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -59,8 +59,18 @@ module Sinatra
       app.helpers ActiveRecordHelper
 
       # re-connect if database connection dropped (Rails 3 only)
-      app.before { ActiveRecord::Base.verify_active_connections! if ActiveRecord::Base.respond_to?(:verify_active_connections!) }
-      app.after { ActiveRecord::Base.clear_active_connections! }
+      app.before do
+        if ActiveRecord::VERSION::MAJOR == 3
+          ActiveRecord::Base.verify_active_connections! if ActiveRecord::Base.respond_to?(:verify_active_connections!)
+        end
+      end
+      app.after do
+        if ActiveRecord::VERSION::MAJOR < 7
+          ActiveRecord::Base.clear_active_connections!
+        else
+          ActiveRecord::Base.connection_handler.clear_active_connections!
+        end
+      end
     end
 
     def database_file=(path)


### PR DESCRIPTION
problem
---------

With ActiveRecord v7, this gem is still working but it reports a deprecation warning.

This is from a Sinatra app with `sinatra-activerecord` version 2.0.2.

```
web    | DEPRECATION WARNING: Calling `ActiveRecord::Base.clear_active_connections! is deprecated. Please call the method directly on the connection handler; for example: `ActiveRecord::Base.connection_handler.clear_active_connections!`. (called from load at /Users/jon/.rbenv/versions/2.7.6/bin/rackup:23)
```

solution
---------

This PR condititionally calls `clear_active_connections!` off the `connection_handler` for ActiveSupport versions of 7 or greater and retains the old behavior for older versions.

tests
-----

The test suite here still passes, and I pulled this gem into my app and watched the deprecation message go away.