### PR TITLE
Fix spec environment and deprecation warning seen with ActiveRecord v 7.1

### DIFF
--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -59,8 +59,18 @@ module Sinatra
       app.helpers ActiveRecordHelper
 
       # re-connect if database connection dropped (Rails 3 only)
-      app.before { ActiveRecord::Base.verify_active_connections! if ActiveRecord::Base.respond_to?(:verify_active_connections!) }
-      app.after { ActiveRecord::Base.clear_active_connections! }
+      app.before do
+        if ActiveRecord::VERSION::MAJOR == 3
+          ActiveRecord::Base.verify_active_connections! if ActiveRecord::Base.respond_to?(:verify_active_connections!)
+        end
+      end
+      app.after do
+        if ActiveRecord::VERSION::MAJOR < 7
+          ActiveRecord::Base.clear_active_connections!
+        else
+          ActiveRecord::Base.connection_handler.clear_active_connections!
+        end
+      end
     end
 
     def database_file=(path)

--- a/spec/sinatra/activerecord/rake_spec.rb
+++ b/spec/sinatra/activerecord/rake_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe "the rake tasks" do
 
   it "has all the rake tasks working" do
     begin
+      # by default we configure a development database
+      ENV['RAILS_ENV'] = 'development'
       ENV["NAME"] = "create_users"
 
       Rake::Task["db:create"].invoke


### PR DESCRIPTION
Original Pull Request by @bunnymatic : #128 

This PR also fixes the DB environment setting in rake_spec.rb (as recent ActiveRecord will throw Environment Mismatch error if the environment is different when running in test mode)

