### PR TITLE
Fix ActiveRecord::Base.establish_connection

### DIFF
--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -93,7 +93,7 @@ module Sinatra
         ActiveRecord::Base.establish_connection(spec.stringify_keys)
       else
         if Gem.loaded_specs["activerecord"].version >= Gem::Version.create('6.0')
-          ActiveRecord::Base.configurations ||= ActiveRecord::DatabaseConfigurations.new({}).resolve(spec)
+          ActiveRecord::Base.configurations = ActiveRecord::DatabaseConfigurations.new({environment.to_s => spec, "default_env" => spec})
         else
           ActiveRecord::Base.configurations ||= {}
           ActiveRecord::Base.configurations[environment.to_s] = ActiveRecord::ConnectionAdapters::ConnectionSpecification::ConnectionUrlResolver.new(spec).to_hash


### PR DESCRIPTION
Connection management in ActiveRecord >= 6.0 is broken for string urls as configurations are not stored.

E.g. with the error:

```
activerecord-7.2.1/lib/active_record/database_configurations.rb:229:in `resolve_symbol_connection': The `default_env` database is not configured for the `default_env` environment. (ActiveRecord::AdapterNotSpecified)

  Available database configurations are:
```