### PR TITLE
Use newer synax for configuring database for AR6 and above

### DIFF
--- a/lib/sinatra/activerecord.rb
+++ b/lib/sinatra/activerecord.rb
@@ -93,7 +93,7 @@ module Sinatra
         ActiveRecord::Base.establish_connection(spec.stringify_keys)
       else
         if Gem.loaded_specs["activerecord"].version >= Gem::Version.create('6.0')
-          ActiveRecord::Base.configurations ||= ActiveRecord::DatabaseConfigurations.new({}).resolve(spec)
+          ActiveRecord::Base.configurations = ActiveRecord::DatabaseConfigurations.new({environment.to_s => spec, "default_env" => spec})
         else
           ActiveRecord::Base.configurations ||= {}
           ActiveRecord::Base.configurations[environment.to_s] = ActiveRecord::ConnectionAdapters::ConnectionSpecification::ConnectionUrlResolver.new(spec).to_hash


### PR DESCRIPTION
Use newer syntax for configuring database for AR6 and above , use new PR to trigger newer CI- rerun.

Referencing #132 